### PR TITLE
Fix plan adherence probability check

### DIFF
--- a/simulation/processes.py
+++ b/simulation/processes.py
@@ -187,8 +187,10 @@ def proactive_expert_process(env, state, elyx_agents):
             TASK: Write a strategic, big-picture message to Rohan. Acknowledge the milestone and connect the team's day-to-day work back to his highest-level goals. Reassure him of the long-term vision.
             """
 
-        elif random.random() > PLAN_ADHERENCE_PROBABILITY:
-             if state.intervention_plan.adherence_status == "ON_TRACK":
+        # Check if the member deviates from the plan. PLAN_ADHERENCE_PROBABILITY
+        # represents the chance of deviating, not staying on track.
+        elif random.random() < PLAN_ADHERENCE_PROBABILITY:
+            if state.intervention_plan.adherence_status == "ON_TRACK":
                 state.intervention_plan.adherence_status = "DEVIATED"
                 responder = "Ruby"
                 trigger_event = f"""


### PR DESCRIPTION
## Summary
- fix plan adherence logic to trigger deviations using `random.random() < PLAN_ADHERENCE_PROBABILITY`
- clarify that `PLAN_ADHERENCE_PROBABILITY` is the chance to deviate from the plan

## Testing
- `pip install dspy simpy python-dotenv openai pydantic` *(fails: Could not find a version that satisfies the requirement dspy)*
- `python - <<'PY'
import random
from config import PLAN_ADHERENCE_PROBABILITY
trials = 100000
count_deviated = 0
for _ in range(trials):
    if random.random() < PLAN_ADHERENCE_PROBABILITY:
        count_deviated += 1
print('Observed deviation frequency:', count_deviated / trials)
print('Expected probability:', PLAN_ADHERENCE_PROBABILITY)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689fc40912608328ad0bb78017dced9a